### PR TITLE
refactor(cog): don't hardcode version on load

### DIFF
--- a/onami/cog.py
+++ b/onami/cog.py
@@ -12,16 +12,16 @@ The onami debugging and diagnostics cog implementation.
 """
 
 
-version = "1.0.0a1"
-
-build = "21"
-
-
 import nextcord
 from nextcord.ext import commands
 
+from .meta import __version__
+
+
+build = "21"
+
 try:
-    print(f"Loading Onami v{version}")
+    print(f"Loading Onami v{__version__}")
 
 except:
     print("Failed to load Onami")


### PR DESCRIPTION
## Rationale

This removes the hardcoded `v1.0.0a1` in cog.py since the version has clearly changed as time went by.

## Summary of changes made

Imports \_\_version\_\_ from onami/meta.py.

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the onami module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
