### PR TITLE
fix: add missing version import from onami.meta

### DIFF
--- a/onami/features/shell.py
+++ b/onami/features/shell.py
@@ -14,9 +14,10 @@ The onami shell commands.
 from nextcord.ext import commands
 
 from onami.codeblocks import Codeblock, codeblock_converter
-from onami.cog import build, version
+from onami.cog import build
 from onami.exception_handling import ReplResponseReactor
 from onami.features.baseclass import Feature
+from onami.meta import __version__
 from onami.paginators import PaginatorInterface, WrappedPaginator
 from onami.shell import ShellReader
 
@@ -74,7 +75,7 @@ class ShellFeature(Feature):
         Version showing
         """
 
-        await ctx.reply(f"Onami version {version} and build {build}")
+        await ctx.reply(f"Onami version {__version__} and build {build}")
 
     @Feature.Command(parent="oni", name="pip")
     async def oni_pip(self, ctx: commands.Context, *, argument: codeblock_converter):


### PR DESCRIPTION
## Rationale

This fixes the circular import bug that has to do with `version` not being imported from onami.cog, as #8 changed that to rely on `__version__` instead.

## Summary of changes made

Changes import from `from onami.cog import version` to `from onami.meta import __version__`

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the onami module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
