### PR TITLE
feat(root): add message content intent status

### DIFF
--- a/onami/features/root_command.py
+++ b/onami/features/root_command.py
@@ -149,8 +149,9 @@ class RootCommand(Feature):
         if nextcord.version_info >= (1, 5, 0):
             presence_intent = f"presence intent is {'enabled' if self.bot.intents.presences else 'disabled'}"
             members_intent = f"members intent is {'enabled' if self.bot.intents.members else 'disabled'}"
+            message_content_intent = f"message content intent is {'enabled' if self.bot.intents.message_content else 'disabled'}"
 
-            summary.append(f"{message_cache}, {presence_intent} and {members_intent}.")
+            summary.append(f"{message_cache}, {presence_intent}, {members_intent} and {message_content_intent}.")
         else:
             guild_subscriptions = f"guild subscriptions are {'enabled' if self.bot._connection.guild_subscriptions else 'disabled'}"
 


### PR DESCRIPTION
## Rationale

Since nextcord v2, the message content intent has existed, but Onami still has no support for it. So this PR adds that

## Summary of changes made

Appends a `message content intent is enabled/disabled`

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [ ] This PR changes the onami module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [x] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
