### PR TITLE
fix invite link

### DIFF
--- a/onami/features/management.py
+++ b/onami/features/management.py
@@ -142,7 +142,7 @@ class ManagementFeature(Feature):
         }
 
         return await ctx.send(
-            f"Link to invite this bot:\n<https://nextcord.com/oauth2/authorize?{urlencode(query, safe='+')}>"
+            f"Link to invite this bot:\n<https://discord.com/oauth2/authorize?{urlencode(query, safe='+')}>"
         )
 
     @Feature.Command(parent="oni", name="rtt", aliases=["ping"])


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->

the correct url invite link is discord.com not nextcord.com

## Summary of changes made

<!-- An explanation, in plain English, of your implementation of this change. -->

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the onami module/cog codebase
    - [x] These changes add new functionality to the module/cog
    - [x] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
